### PR TITLE
Flow builder - cleanup and update

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -31,11 +31,6 @@ const App = () => {
     }
   };
 
-  const edges = [];
-  for (let i = 0; i < data.length - 1; ++i) {
-    edges.push(`${data[i].join("+")}.out->${data[i + 1].join("+")}.in`);
-  }
-
   return (
     <div
       style={{
@@ -65,9 +60,6 @@ const App = () => {
           border-radius: 8px;
           box-shadow: 2px 2px 2px 1px rgba(245, 245, 245, 100);
         }
-        .flow-builder--node.drag {
-          border: 1px solid blue;
-        }
         .flow-builder--group {
           border: 1px solid rgb(223, 225, 229);
           border-radius: 8px;
@@ -76,12 +68,9 @@ const App = () => {
         .flow-builder--group .flow-builder--node {
           box-shadow: none;
         }
-        .flow-builder--io-port[data-name$="success"] {
-          background-color: green;
-        }
         `}
       </style>
-      <Graph edges={edges} calculatePath={(from, to) => `M ${from.x} ${from.y} L ${to.x} ${to.y}`}>
+      <Graph>
         {data.map((group) => (
           <Group
             onMouseEnter={() => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keboola/flow-builder",
   "description": "Flow graph rendering",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/Graph.css
+++ b/src/Graph.css
@@ -6,17 +6,6 @@
   height: 100%;
 }
 
-.flow-builder > svg {
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-}
-
-.flow-builder > svg path {
-  stroke: black;
-  fill: transparent;
-}
-
 .flow-builder--node {
   position: absolute;
   display: inline-flex;

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -1,34 +1,17 @@
-import React, { useState, useRef, useEffect } from "react";
-import { v2, processEdge, ProcessedEdge } from "./util";
+import React from "react";
 
-export const Graph = ({ edges, children, style, calculatePath }: Graph.Props) => {
+export const Graph = ({ children, style }: Graph.Props) => {
   if (!children) return null;
 
-  const [paths, setPaths] = useState<ProcessedEdge[]>([]);
-
-  const container = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const containerRect = container.current!.getBoundingClientRect();
-    const offset = v2(containerRect.x, containerRect.y);
-    setPaths(edges.map((edge) => processEdge(container.current!, edge, offset, calculatePath)));
-  }, [edges, calculatePath]);
-
   return (
-    <div ref={container} data-type="graph" className="flow-builder" style={{ ...style }}>
-      <svg>
-        {paths.map((path) => (
-          <path key={path.edge} d={path.d} />
-        ))}
-      </svg>
+    <div data-type="graph" className="flow-builder" style={{ ...style }}>
       {children}
     </div>
   );
 };
 export namespace Graph {
   export type Props = {
-    edges: string[];
     children?: React.ReactNode;
     style?: React.CSSProperties;
-    calculatePath?: (from: { x: number; y: number }, to: { x: number; y: number }) => string;
   };
 }

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
-export const Graph = ({ children, style }: Graph.Props) => {
+export const Graph = ({ children }: Graph.Props) => {
   if (!children) return null;
 
   return (
-    <div data-type="graph" className="flow-builder" style={{ ...style }}>
+    <div data-type="graph" className="flow-builder">
       {children}
     </div>
   );
 };
+
 export namespace Graph {
   export type Props = {
     children?: React.ReactNode;
-    style?: React.CSSProperties;
   };
 }

--- a/src/Group.tsx
+++ b/src/Group.tsx
@@ -27,7 +27,7 @@ export const Group = (props: Group.Props) => {
     }
   }, deps);
   useEffect(() => {
-    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mousemove", onMouseMove, { passive: true });
     return () => window.removeEventListener("mousemove", onMouseMove);
   }, deps);
 

--- a/src/Node.tsx
+++ b/src/Node.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { classes, v2, multiref } from "./util";
 import { filter } from "./Io";
 import { GraphContext } from "./context";
-import { useDrag } from "./drag";
+import { useDrag, DragEventHandler } from "./drag";
 
 export const Node = React.forwardRef<HTMLDivElement, Node.Props>((props, fref) => {
   if (!props.children) return null;
@@ -65,9 +65,9 @@ export namespace Node {
     className?: string;
     children?: React.ReactNode;
     draggable?: boolean;
-    onDragStart?: (position: [number, number]) => void;
-    onDragMove?: (position: [number, number]) => void;
-    onDragEnd?: (position: [number, number]) => void;
+    onDragStart?: DragEventHandler;
+    onDragMove?: DragEventHandler;
+    onDragEnd?: DragEventHandler;
     onSelect?: () => void;
   };
 }

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -76,7 +76,6 @@ export function useDrag({
       );
     }, deps),
     useCallback((evt: React.MouseEvent) => {
-      evt.preventDefault();
       dragState.start = v2(evt.clientX, evt.clientY);
     }, deps)
   ] as const;

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { v2, Vector2, findParent } from "./util";
 
-export type DragEventHandler = (position: [number, number]) => void;
+export type DragEventHandler = (position: [number, number], client?: [number, number]) => void;
 export function useDrag({
   onDragStart,
   onDragMove,
@@ -39,7 +39,7 @@ export function useDrag({
       const rmpos = mpos.subtract(offset());
       if (dragState.current) {
         dragState.current = rmpos;
-        onDragMove?.(rmpos.array());
+        onDragMove?.(rmpos.array(), [evt.clientY, evt.clientX]);
       } else if (dragState.start.dist(mpos) > 20) {
         dragState.current = rmpos;
         onDragStart?.(rmpos.array());

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,10 +9,6 @@ export class Vector2 {
     return Math.hypot(that.x - this.x, that.y - this.y);
   }
 
-  toString() {
-    return `[${this.x.toFixed(2)}, ${this.y.toFixed(2)}]`;
-  }
-
   css() {
     return { left: `${this.x}px`, top: `${this.y}px` };
   }
@@ -27,14 +23,6 @@ export class Vector2 {
 export const v2 = (x: number = 0, y: number = 0) => new Vector2(x, y);
 v2.from = (v: [number, number] | MouseEvent) =>
   v instanceof MouseEvent ? new Vector2(v.clientX, v.clientY) : new Vector2(v[0], v[1]);
-/**
- * Calculates the midpoint of `a` and `b`
- */
-v2.pmid = (a: Vector2, b: Vector2) => new Vector2((a.x + b.x) / 2, (a.y + b.y) / 2);
-/**
- * Calculates the midpoint of `rect`
- */
-v2.rectMid = (rect: DOMRect) => new Vector2(rect.x + rect.width / 2, rect.y + rect.height / 2);
 v2.offsetOf = (rect: DOMRect) => new Vector2(rect.left, rect.top);
 
 /**
@@ -55,30 +43,6 @@ export const classes = (...v: (string | [string, boolean])[]) =>
     })
     .filter((v) => v !== null)
     .join(" ");
-
-/**
- * SVG path generators
- *
- * Usage:
- * ```jsx
- * <path d={path.line(v2(0, 0), v2(50, 50))} />
- * <path d={path.bezier(v2(0, 0), v2(50, 50))} />
- * ```
- */
-export const path = {
-  line: (start: { x: number; y: number }, end: { x: number; y: number }) =>
-    `M ${start.x} ${start.y} L ${end.x} ${end.y}`,
-  bezier: (start: { x: number; y: number }, end: { x: number; y: number }) => {
-    const mid = v2.pmid(v2(start.x, start.y), v2(end.x, end.y));
-    const dx = end.x - start.x;
-    const dy = end.y - start.y;
-    return (
-      `M ${start.x} ${start.y} ` +
-      `Q ${start.x - dx / 32} ${start.y + dy / 2}, ${mid.x} ${mid.y} ` +
-      `T ${end.x} ${end.y}`
-    );
-  }
-};
 
 /**
  * Remove from `array` all items for which `predicate` is `true`,
@@ -116,47 +80,6 @@ export const removeAll = <T>(
   return removed;
 };
 
-const EDGE_REGEX = /(.+\..+)->(.+\..+)/;
-
-export interface ProcessedEdge {
-  edge: string;
-  d: string;
-}
-export const processEdge = (
-  container: ParentNode,
-  edge: string,
-  offset: Vector2,
-  calculatePath: (
-    from: { x: number; y: number },
-    to: { x: number; y: number }
-  ) => string = path.bezier
-): ProcessedEdge => {
-  const info = edge.match(EDGE_REGEX);
-  if (!info) {
-    throw new Error(
-      `flow-builder: Invalid edge '${edge}', the format should be \`\${source}.\${output}->\${destination}.\${input}`
-    );
-  }
-
-  const [src, dst] = info.slice(1);
-  const from = container.querySelector(`div[data-name='${src}']`);
-  const to = container.querySelector(`div[data-name='${dst}']`);
-  if (!from || !to) {
-    const [which, io] = from ? ["destination", "input"] : ["source", "output"];
-    throw new Error(
-      `flow-builder: Invalid edge '${edge}', ${which} node does not exist or has no such ${io}`
-    );
-  }
-  if (from.parentElement!.dataset.type === "group" || to.parentElement!.dataset.type === "group") {
-    const which = from.parentElement!.dataset.type === "group" ? "source" : "destination";
-    throw new Error(`flow-builder: Invalid edge '${edge}', ${which} node is inside a group`);
-  }
-
-  const srcMid = v2.rectMid(from.getBoundingClientRect()).subtract(offset);
-  const dstMid = v2.rectMid(to.getBoundingClientRect()).subtract(offset);
-  return { edge, d: calculatePath(srcMid, dstMid) };
-};
-
 export function* walkParents(start: HTMLElement) {
   let parent = start.parentElement;
   while (parent) {
@@ -188,5 +111,3 @@ export function multiref<T extends Element>(
     }
   };
 }
-
-export const NOOP = function NOOP() {};


### PR DESCRIPTION
Toto bude lepší jít po commitech:

1. vyhodil jsem props `edges` a `calculatePath` - v UI už se to nepoužívá a je kolem toho zde "hodně"logiky
2. v Group mohl být jeden listener passive tak jsem mu to přidal
3. vyhodil jsem s onMouseDown prevent default který dělal ty problémy v UI - zkoumal jsme proč to zde je ale myslím že navíc, testoval jsme to bez toho a vše funguje stejně co vidím..
4. navíc jsem do onDragMove přidal `client` pole kde je pozice myši na obrazovce.. Honza nebyl fanda aby se posílal celý event takže to řeším ve stejným duchu jako `position` parametr... jinak využití může být ten automatický scrolll když dojdu úplně dolů na stránku třeba