### PR TITLE
Remove duplicated client params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keboola/flow-builder",
   "description": "Flow graph rendering",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/drag.ts
+++ b/src/drag.ts
@@ -39,7 +39,7 @@ export function useDrag({
       const rmpos = mpos.subtract(offset());
       if (dragState.current) {
         dragState.current = rmpos;
-        onDragMove?.(rmpos.array(), [evt.clientY, evt.clientX]);
+        onDragMove?.(rmpos.array(), mpos.array());
       } else if (dragState.start.dist(mpos) > 20) {
         dragState.current = rmpos;
         onDragStart?.(rmpos.array());


### PR DESCRIPTION
Tak ještě jeden update kde to zase mažu.

- všiml jsem si zaprvé že to posílám v opačném pořadí.. teda Y a X, i když první parametr je X a Y
- hlavní co tak mě nedošlo že ten první parametr `position` je přesně to samé.. že ten offset se počítá pak až v kbc-ui