### PR TITLE
Support only left mouse click

### DIFF
--- a/src/drag.ts
+++ b/src/drag.ts
@@ -76,6 +76,7 @@ export function useDrag({
       );
     }, deps),
     useCallback((evt: React.MouseEvent) => {
+      if (evt.button !== 0) return;
       dragState.start = v2(evt.clientX, evt.clientY);
     }, deps)
   ] as const;


### PR DESCRIPTION
Zde se obecně nepracuje s onclick ale s mousedown a mouseup. Ale i tak dává smysl podporovat pouze levé tlačítko myši. Middle nebo pravý click by se neměl chovat stejně..