### PR TITLE
Simplify copy config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keboola/flow-builder",
   "description": "Flow graph rendering",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,12 +24,5 @@ export default {
       }
     }
   ],
-  plugins: [
-    clean("dist"),
-    nodeResolve(),
-    commonjs(),
-    typescript(),
-    copy({ targets: [{ src: "src/Graph.css", dest: "dist" }] }),
-    terser()
-  ]
+  plugins: [clean("dist"), nodeResolve(), commonjs(), typescript(), copy("src/Graph.css"), terser()]
 };


### PR DESCRIPTION
Ten "copy" automaticky kopíruje do dist, takže to tam bylo nadvakárt,, jako `dist/dist/Graph.css` tak je úprava.. jakože mohl bych to takto načítat v UI ale lepší to hned upraivt.